### PR TITLE
#41 implement get articles by category

### DIFF
--- a/src/controllers/articleController.js
+++ b/src/controllers/articleController.js
@@ -63,7 +63,7 @@ exports.createArticle = async (req, res) => {
       // check if category exists in db
       const isCategory = await Category.findByProps({ category });
       if (!isCategory.rowCount) {
-        throw new ResponseError(400, 'Selected category is unavailabe');
+        throw new ResponseError(400, 'Selected category is unavailable');
       }
       clientData.categoryId = isCategory.rows[0].id;
     }
@@ -118,23 +118,6 @@ exports.updateArticle = async (req, res) => {
     const isArticle = await Article.findById(articleId);
 
     if (!isArticle.rowCount) { throw new ResponseError(404, 'Oops! The article you want to update seems to missing'); }
-
-    // const { userId } = req.body;
-
-    // check that the user id is the same as the article author id before permitting updating
-    // if (isArticle.rows[0].author_id !== userId) {
-    //   throw new ResponseError(401, 'You don\'t have permissions to update this post');
-    // }
-
-    // check if the article title is still unique
-    // const isArticleUnique = await Article.findByProps({
-    //   title: clientData.title,
-    //   id: `!${articleId}`,
-    // });
-
-    // if (isArticleUnique.rowCount) {
-    //   throw new ResponseError(400, 'Article title must be unique');
-    // }
 
     // ****** if everything else is good, post data to db ******
 
@@ -230,6 +213,30 @@ exports.postComment = async (req, res) => {
       comment,
       createdOn: _timestamp,
     });
+  } catch (error) {
+    consoleLogger.log(error);
+    sendResponse(res, error.statusCode, 'error', error.message);
+  }
+};
+
+exports.getByCategory = async (req, res) => {
+  const { tag } = req.query;
+  try {
+    // check if category exists
+    const { rowCount, rows } = await Category.findByProps({ category: tag });
+    if (!rowCount) { throw new ResponseError(404, 'Selected category is unavailable'); }
+
+    // get articles in the selected category
+    const result = await Article.findByProps({ category_id: rows[0].id });
+
+    // check if there is an existing article in the selected category
+    if (!result.rowCount) {
+      return sendResponse(res, 200, 'success', {
+        message: 'There is currently no article in selected category',
+      });
+    }
+    // send list of articles
+    sendResponse(res, 200, 'success', result.rows);
   } catch (error) {
     consoleLogger.log(error);
     sendResponse(res, error.statusCode, 'error', error.message);

--- a/src/routes/apiV1/articleRoute.js
+++ b/src/routes/apiV1/articleRoute.js
@@ -5,12 +5,14 @@ const {
   updateArticle,
   deleteArticle,
   postComment,
+  getByCategory,
 } = require('../../controllers/articleController');
 
 const router = Router();
 
 router.route('/')
-  .post(createArticle);
+  .post(createArticle)
+  .get(getByCategory);
 
 router.route('/:articleId')
   .get(getArticle)

--- a/src/tests/articles.spec.js
+++ b/src/tests/articles.spec.js
@@ -466,9 +466,9 @@ globalSpec('Articles', () => {
     });
 
     it('should return a 400 status code if the selected category does not exist in the category table', (done) => {
-      // 'a' is not a default category in the categories table in the database of the application
-      request(method, `${endpoint}?tag=a`, headers, null, (error, response, body) => {
-        expect(response.statusCode).toEqual(400);
+      // 'aaaa' is not a default category in the categories table in the database of the application
+      request(method, `${endpoint}?tag=aaaa`, headers, null, (error, response, body) => {
+        expect(response.statusCode).toEqual(404);
         expect(body.status).toBe('error');
         done();
       });

--- a/src/tests/articles.spec.js
+++ b/src/tests/articles.spec.js
@@ -108,6 +108,7 @@ globalSpec('Articles', () => {
     it('should return a 400 status code if the category supplied does not exist in the categories table', (done) => {
       request(method, endpoint, headers, unavailableTag, (error, response, body) => {
         expect(response.statusCode).toEqual(400);
+        expect(body.status).toBe('error');
         done();
       });
     });
@@ -426,6 +427,49 @@ globalSpec('Articles', () => {
       request(method, endpoint, malformedToken, null, (error, response, body) => {
         expect(response.statusCode).toEqual(401);
         expect(body.error).toBe('jwt malformed');
+        done();
+      });
+    });
+  });
+
+  // GET ARTICLES BY CATEGORY
+  describe('GET /api/v1/articles?tag=<category>', () => {
+    const method = 'get';
+    const endpoint = '/api/v1/articles';
+
+    beforeAll((done) => {
+      // Create an article to be utilized by the rest of the suite.
+      request('post', endpoint, headers, completeArticleData6, (error, response, body) => {
+        // insert the article id into the endpoint
+        expect(response.statusCode).toEqual(201);
+        expect(body.status).toBe('success');
+        done();
+      });
+    });
+
+    it('should return a 200 status code if articles are returned successfully', (done) => {
+      // 'finance' is a default category in the categories table in the database of the application
+      request(method, `${endpoint}?tag=finance`, headers, null, (error, response, body) => {
+        expect(response.statusCode).toEqual(200);
+        expect(body.status).toBe('success');
+        done();
+      });
+    });
+
+    it('should return a 200 status code if the category exists, but there is currently no article in that category', (done) => {
+      // 'research' is a default category in the categories table in the database of the application
+      request(method, `${endpoint}?tag=research`, headers, null, (error, response, body) => {
+        expect(response.statusCode).toEqual(200);
+        expect(body.status).toBe('success');
+        done();
+      });
+    });
+
+    it('should return a 400 status code if the selected category does not exist in the category table', (done) => {
+      // 'a' is not a default category in the categories table in the database of the application
+      request(method, `${endpoint}?tag=a`, headers, null, (error, response, body) => {
+        expect(response.statusCode).toEqual(400);
+        expect(body.status).toBe('error');
         done();
       });
     });

--- a/src/tests/gif.spec.js
+++ b/src/tests/gif.spec.js
@@ -155,7 +155,7 @@ globalSpec('Gifs', () => {
     let endpoint1;
 
     beforeAll((done) => {
-      // Create an article to be utilized by the rest of the suite.
+      // Create a gif to be utilized by the rest of the suite.
       request.post({
         uri: endpoint,
         headers,


### PR DESCRIPTION
#### What does this PR do?
implement get articles by category
Update pg configuration to connect to the postgresql database using a connection string
#### Description of Task to be completed?
- create `/api/v1/articles?tag=<category>
- write unit tests for `getByCategory` controller
- implement `getByCategory` controller
- document the endpoint
- refactor the server host to use the environment variable `HOST` in  production
#### How should this be manually tested?
* clone the repository
* run `npm install`
* run `npm tests` to test all the endpoints
#### Any background context you want to provide?
the acceptable/default categories are:
* analytics
* research
* communication
* finance
#### What are the relevant pivotal tracker stories?
#41
#### Screenshots (if appropriate)
#### Questions: